### PR TITLE
feat: add SHA1 and MD5 hashing support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ venv/
 target/
 rust-toolchain.toml
 *.pyc
+*.so

--- a/polars_hash/polars_hash/Cargo.toml
+++ b/polars_hash/polars_hash/Cargo.toml
@@ -8,16 +8,17 @@ name = "polars_hash"
 crate-type = ["cdylib"]
 
 [dependencies]
-polars = { version = "0.37.0", features = ["dtype-struct"]}
-polars-arrow = { version = "0.37.0"}
+polars = { version = "0.37.0", features = ["dtype-struct"] }
+polars-arrow = { version = "0.37.0" }
 pyo3 = { version = "0.20", features = ["extension-module"] }
 pyo3-polars = { version = "0.11.0", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
-wyhash = {version = "0.5.0"}
-geohash = {version = "0.13.0"}
-sha2 = {version = "0.10.8"}
-sha3 = {version = "0.10.8"}
-blake3 = {version = "1.5.0" } 
+wyhash = { version = "0.5.0" }
+geohash = { version = "0.13.0" }
+sha1 = { version = "0.10.6" }
+sha2 = { version = "0.10.8" }
+sha3 = { version = "0.10.8" }
+blake3 = { version = "1.5.0" }
 
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/polars_hash/polars_hash/Cargo.toml
+++ b/polars_hash/polars_hash/Cargo.toml
@@ -19,6 +19,7 @@ sha1 = { version = "0.10.6" }
 sha2 = { version = "0.10.8" }
 sha3 = { version = "0.10.8" }
 blake3 = { version = "1.5.0" }
+md5 = {version = "0.7.0"}
 
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/polars_hash/polars_hash/polars_hash/__init__.py
+++ b/polars_hash/polars_hash/polars_hash/__init__.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
-import polars as pl
+
 import warnings
-from polars.utils.udfs import _get_shared_lib_location
+from typing import Iterable, Protocol, cast
+
+import polars as pl
+from polars.type_aliases import IntoExpr, PolarsDataType
 from polars.utils._parse_expr_input import parse_as_expression
 from polars.utils._wrap import wrap_expr
-from typing import Protocol, Iterable, cast
-from polars.type_aliases import PolarsDataType, IntoExpr
+from polars.utils.udfs import _get_shared_lib_location
+
 from ._internal import __version__ as __version__
 
 lib = _get_shared_lib_location(__file__)
@@ -112,6 +115,14 @@ class NonCryptographicHashingNameSpace:
         return self._expr.register_plugin(
             lib=lib,
             symbol="wyhash",
+            is_elementwise=True,
+        )
+
+    def sha1(self) -> pl.Expr:
+        """Takes Utf8 as input and returns utf8 hash with sha1."""
+        return self._expr.register_plugin(
+            lib=lib,
+            symbol="sha1",
             is_elementwise=True,
         )
 

--- a/polars_hash/polars_hash/polars_hash/__init__.py
+++ b/polars_hash/polars_hash/polars_hash/__init__.py
@@ -126,6 +126,14 @@ class NonCryptographicHashingNameSpace:
             is_elementwise=True,
         )
 
+    def md5(self) -> pl.Expr:
+        """Takes Utf8 as input and returns utf8 hash with md5."""
+        return self._expr.register_plugin(
+            lib=lib,
+            symbol="md5",
+            is_elementwise=True,
+        )
+
 
 @pl.api.register_expr_namespace("geohash")
 class GeoHashingNameSpace:

--- a/polars_hash/polars_hash/src/expressions.rs
+++ b/polars_hash/polars_hash/src/expressions.rs
@@ -18,6 +18,11 @@ pub fn blake3_hash(value: &str, output: &mut string::String) {
     write!(output, "{}", hash).unwrap()
 }
 
+pub fn md5_hash(value: &str, output: &mut string::String) {
+    let hash = md5::compute(value);
+    write!(output, "{:x}", hash).unwrap()
+}
+
 fn wyhash_hash(value: Option<&str>) -> Option<u64> {
     value.map(|v| real_wyhash(v.as_bytes(), 0))
 }
@@ -40,6 +45,13 @@ fn blake3(inputs: &[Series]) -> PolarsResult<Series> {
 fn sha1(inputs: &[Series]) -> PolarsResult<Series> {
     let ca = inputs[0].str()?;
     let out: StringChunked = ca.apply_to_buffer(sha1_hash);
+    Ok(out.into_series())
+}
+
+#[polars_expr(output_type=String)]
+fn md5(inputs: &[Series]) -> PolarsResult<Series> {
+    let ca = inputs[0].str()?;
+    let out: StringChunked = ca.apply_to_buffer(md5_hash);
     Ok(out.into_series())
 }
 

--- a/polars_hash/polars_hash/src/expressions.rs
+++ b/polars_hash/polars_hash/src/expressions.rs
@@ -37,6 +37,13 @@ fn blake3(inputs: &[Series]) -> PolarsResult<Series> {
 }
 
 #[polars_expr(output_type=String)]
+fn sha1(inputs: &[Series]) -> PolarsResult<Series> {
+    let ca = inputs[0].str()?;
+    let out: StringChunked = ca.apply_to_buffer(sha1_hash);
+    Ok(out.into_series())
+}
+
+#[polars_expr(output_type=String)]
 fn sha2_256(inputs: &[Series]) -> PolarsResult<Series> {
     let ca = inputs[0].str()?;
     let out: StringChunked = ca.apply_to_buffer(sha2_256_hash);

--- a/polars_hash/polars_hash/src/sha_hashers.rs
+++ b/polars_hash/polars_hash/src/sha_hashers.rs
@@ -1,6 +1,12 @@
+use sha1::{Sha1};
 use sha2::{Digest, Sha224, Sha256, Sha384, Sha512};
 use sha3::{Sha3_224, Sha3_256, Sha3_384, Sha3_512};
 use std::fmt::Write;
+
+pub fn sha1_hash(value: &str, output: &mut String) {
+    let hash = Sha1::digest(value);
+    write!(output, "{:x}", hash).unwrap()
+}
 
 pub fn sha2_256_hash(value: &str, output: &mut String) {
     let hash = Sha256::digest(value);

--- a/polars_hash/tests/test_hash.py
+++ b/polars_hash/tests/test_hash.py
@@ -1,7 +1,7 @@
 import polars as pl
-import polars_hash as plh  # noqa: F401
-
 from polars.testing import assert_frame_equal
+
+import polars_hash as plh  # noqa: F401
 
 
 def test_sha1():
@@ -40,6 +40,18 @@ def test_wyhash():
     expected = pl.DataFrame(
         [
             pl.Series("literal", [16737367591072095403], dtype=pl.UInt64),
+        ]
+    )
+
+    assert_frame_equal(result, expected)
+
+
+def test_md5():
+    result = pl.select(pl.lit("hello_world").nchash.md5())  # type: ignore
+
+    expected = pl.DataFrame(
+        [
+            pl.Series("literal", ["99b1ff8f11781541f7f89f9bd41c4a17"], dtype=pl.Utf8),
         ]
     )
 

--- a/polars_hash/tests/test_hash.py
+++ b/polars_hash/tests/test_hash.py
@@ -4,6 +4,21 @@ import polars_hash as plh  # noqa: F401
 from polars.testing import assert_frame_equal
 
 
+def test_sha1():
+    result = pl.select(pl.lit("hello_world").nchash.sha1())  # type: ignore
+
+    expected = pl.DataFrame(
+        [
+            pl.Series(
+                "literal",
+                ["e4ecd6fc11898565af24977e992cea0c9c7b7025"],
+                dtype=pl.Utf8,
+            ),
+        ]
+    )
+    assert_frame_equal(result, expected)
+
+
 def test_sha256():
     result = pl.select(pl.lit("hello_world").chash.sha2_256())  # type: ignore
 


### PR DESCRIPTION
Added support for non-cryptographic SHA1 and MD5 hashes, still useful for non-cryptographic usecases.