### PR TITLE
#27 DeprecationWarning: The `polars.type_aliases` module is deprecated

### DIFF
--- a/polars_hash/polars_hash/__init__.py
+++ b/polars_hash/polars_hash/__init__.py
@@ -3,15 +3,13 @@ from __future__ import annotations
 import warnings
 from pathlib import Path
 from typing import Iterable, Protocol, cast
-from packaging.version import Version
 
 import polars as pl
 from polars.plugins import register_plugin_function
 
-if Version(pl.__version__) >= Version("1.0"):
+try:
     from polars._typing import IntoExpr, PolarsDataType
-
-else:
+except ImportError:
     from polars.type_aliases import IntoExpr, PolarsDataType
 
 from polars_hash._internal import __version__ as __version__

--- a/polars_hash/polars_hash/__init__.py
+++ b/polars_hash/polars_hash/__init__.py
@@ -10,7 +10,7 @@ from polars.plugins import register_plugin_function
 try:
     from polars._typing import IntoExpr, PolarsDataType
 except ImportError:
-    from polars.type_aliases import IntoExpr, PolarsDataType
+    from polars.type_aliases import IntoExpr, PolarsDataType  # type: ignore[no-redef]
 
 from polars_hash._internal import __version__ as __version__
 

--- a/polars_hash/polars_hash/__init__.py
+++ b/polars_hash/polars_hash/__init__.py
@@ -3,10 +3,16 @@ from __future__ import annotations
 import warnings
 from pathlib import Path
 from typing import Iterable, Protocol, cast
+from packaging.version import Version
 
 import polars as pl
 from polars.plugins import register_plugin_function
-from polars.type_aliases import IntoExpr, PolarsDataType
+
+if Version(pl.__version__) >= Version("1.0"):
+    from polars._typing import IntoExpr, PolarsDataType
+
+else:
+    from polars.type_aliases import IntoExpr, PolarsDataType
 
 from polars_hash._internal import __version__ as __version__
 

--- a/polars_hash/requirements.txt
+++ b/polars_hash/requirements.txt
@@ -4,4 +4,4 @@ pytest
 mypy
 ruff
 black
-packaging
+

--- a/polars_hash/requirements.txt
+++ b/polars_hash/requirements.txt
@@ -4,3 +4,4 @@ pytest
 mypy
 ruff
 black
+packaging


### PR DESCRIPTION
Polars moved some of their type aliases to private modules temporarily.  The simplest workaround is the following PR, here's their changelog describing the issue.

https://docs.pola.rs/releases/upgrade/1/#remove-re-export-of-type-aliases

Since this only appears in polars versions >= 1.0, I added `packaging` to the deps to help disambiguate which version the user is on.