### PR TITLE
Fixed typo in HashConcatStr

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -109,7 +109,7 @@ jobs:
           args: --release --out dist --find-interpreter --manifest-path polars_hash/Cargo.toml
           sccache: 'true'
       - name: Upload wheels
-        uses: actions/upload-artifact@v44
+        uses: actions/upload-artifact@v4
         with:
           name: wheels
           path: dist

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -109,7 +109,7 @@ jobs:
           args: --release --out dist --find-interpreter --manifest-path polars_hash/Cargo.toml
           sccache: 'true'
       - name: Upload wheels
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v44
         with:
           name: wheels
           path: dist
@@ -135,7 +135,7 @@ jobs:
     if: "startsWith(github.ref, 'refs/tags/')"
     needs: [linux_tests, linux, macos, windows, sdist]
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: wheels
       - name: Publish to PyPI

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -134,7 +134,7 @@ jobs:
     needs: [linux_tests, linux, macos, windows, sdist]
     steps:
       - name: Merge wheels
-        uses: actions/upload-artifacts/merge@v4
+        uses: actions/upload-artifact/merge@v4
         with:
           name: wheels
           pattern: wheels-*

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: wheels-linux-${{ matrix.target }}
           path: dist
 
   windows:
@@ -89,7 +89,7 @@ jobs:
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: wheels-windows-${{ matrix.target }}
           path: dist
 
   macos:
@@ -111,7 +111,7 @@ jobs:
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: wheels-macos-${{ matrix.target }}
           path: dist
 
   sdist:
@@ -126,14 +126,24 @@ jobs:
       - name: Upload sdist
         uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: wheels-sdist
           path: dist
+
+  merge_wheels:
+    runs-on: ubuntu-latest
+    needs: [linux_tests, linux, macos, windows, sdist]
+    steps:
+      - name: Merge wheels
+        uses: actions/upload-artifacts/merge@v4
+        with:
+          name: wheels
+          pattern: wheels-*
 
   release:
     name: Release
     runs-on: ubuntu-latest
     if: "startsWith(github.ref, 'refs/tags/')"
-    needs: [linux_tests, linux, macos, windows, sdist]
+    needs: [linux_tests, linux, macos, windows, sdist, merge_wheels]
     steps:
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -64,7 +64,7 @@ jobs:
           sccache: 'true'
           manylinux: auto
       - name: Upload wheels
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: wheels
           path: dist
@@ -87,7 +87,7 @@ jobs:
           args: --release --out dist --find-interpreter --manifest-path polars_hash/Cargo.toml
           sccache: 'true'
       - name: Upload wheels
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: wheels
           path: dist
@@ -124,7 +124,7 @@ jobs:
           command: sdist
           args: --out dist --manifest-path polars_hash/Cargo.toml
       - name: Upload sdist
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: wheels
           path: dist

--- a/polars_hash/Cargo.toml
+++ b/polars_hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polars_hash"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 
 [lib]

--- a/polars_hash/polars_hash/__init__.py
+++ b/polars_hash/polars_hash/__init__.py
@@ -299,7 +299,7 @@ class HashConcatStr(Protocol):
         self,
         exprs: IntoExpr | Iterable[IntoExpr],
         *more_exprs: IntoExpr,
-        seperator: str = "",
+        separator: str = "",
     ) -> HExpr: ...
 
     def __getattr__(self, name: str) -> pl.Expr: ...

--- a/polars_hash/polars_hash/__init__.py
+++ b/polars_hash/polars_hash/__init__.py
@@ -300,6 +300,7 @@ class HashConcatStr(Protocol):
         exprs: IntoExpr | Iterable[IntoExpr],
         *more_exprs: IntoExpr,
         separator: str = "",
+        ignore_nulls: bool = False,
     ) -> HExpr: ...
 
     def __getattr__(self, name: str) -> pl.Expr: ...

--- a/polars_hash/pyproject.toml
+++ b/polars_hash/pyproject.toml
@@ -18,6 +18,7 @@ authors = [
 ]
 description = "Stable non-cryptographic and cryptographic hashing functions for Polars"
 readme = "README.md"
+dynamic = ["version"]
 
 [project.urls]
 "Homepage" = "https://github.com/ion-elgreco/polars-hash"


### PR DESCRIPTION
Fixed minor typo in `HashConcatStr.__call__`'s arguments.