### PR TITLE
:arrow_up: bump polars to >=1.0.0

### DIFF
--- a/polars_hash/polars_hash/Cargo.toml
+++ b/polars_hash/polars_hash/Cargo.toml
@@ -8,10 +8,10 @@ name = "polars_hash"
 crate-type = ["cdylib"]
 
 [dependencies]
-polars = { version = "0.37.0", features = ["dtype-struct"] }
-polars-arrow = { version = "0.37.0" }
-pyo3 = { version = "0.20", features = ["extension-module", "abi3-py38"] }
-pyo3-polars = { version = "0.11.0", features = ["derive"] }
+polars = { version = "0.41", features = ["dtype-struct"] }
+polars-arrow = { version = "0.41" }
+pyo3 = { version = "0.21", features = ["extension-module", "abi3-py38"] }
+pyo3-polars = { version = "0.15", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 wyhash = { version = "0.5.0" }
 geohash = { version = "0.13.0" }
@@ -20,7 +20,3 @@ sha2 = { version = "0.10.8" }
 sha3 = { version = "0.10.8" }
 blake3 = { version = "1.5.0" }
 md5 = {version = "0.7.0"}
-
-
-[target.'cfg(target_os = "linux")'.dependencies]
-jemallocator = { version = "0.5", features = ["disable_initial_exec_tls"] }

--- a/polars_hash/polars_hash/polars_hash/__init__.py
+++ b/polars_hash/polars_hash/polars_hash/__init__.py
@@ -1,17 +1,18 @@
 from __future__ import annotations
 
+from pathlib import Path
 import warnings
 from typing import Iterable, Protocol, cast
 
 import polars as pl
 from polars.type_aliases import IntoExpr, PolarsDataType
-from polars.utils._parse_expr_input import parse_as_expression
-from polars.utils._wrap import wrap_expr
-from polars.utils.udfs import _get_shared_lib_location
+from polars._utils.parse.expr import parse_into_expression
+from polars._utils.wrap import wrap_expr
+
 
 from ._internal import __version__ as __version__
 
-lib = _get_shared_lib_location(__file__)
+lib = Path(__file__).parent
 
 
 @pl.api.register_expr_namespace("chash")
@@ -150,7 +151,7 @@ class GeoHashingNameSpace:
 
     def from_coords(self, len: int | str | pl.Expr = 12) -> pl.Expr:
         """Takes Struct with latitude, longitude as input and returns utf8 hash using geohash."""
-        len_expr = wrap_expr(parse_as_expression(len))
+        len_expr = wrap_expr(parse_into_expression(len))
         return self._expr.register_plugin(
             lib=lib,
             args=[len_expr],

--- a/polars_hash/polars_hash/pyproject.toml
+++ b/polars_hash/polars_hash/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "maturin"
 name = "polars-hash"
 requires-python = ">=3.8"
 dependencies = [
-  'polars >= 0.20.6'
+  'polars >= 1.0.0'
 ]
 classifiers = [
   "Programming Language :: Rust",
@@ -18,6 +18,7 @@ authors = [
 ]
 description = "Stable non-cryptographic and cryptographic hashing functions for Polars"
 readme = "README.md"
+dynamic = ["version"]
 
 [project.urls]
 "Homepage" = "https://github.com/ion-elgreco/polars-hash"

--- a/polars_hash/polars_hash/src/expressions.rs
+++ b/polars_hash/polars_hash/src/expressions.rs
@@ -4,10 +4,8 @@ use polars::{
     chunked_array::ops::arity::{try_binary_elementwise, try_ternary_elementwise},
     prelude::*,
 };
-use polars_core::datatypes::{
-    DataType::{Float64, String, Struct},
-    Field,
-};
+use polars::datatypes::DataType;
+use polars::datatypes::Field;
 use pyo3_polars::derive::polars_expr;
 use std::fmt::Write;
 use std::{str, string};
@@ -156,10 +154,10 @@ fn ghash_encode(inputs: &[Series]) -> PolarsResult<Series> {
 
 pub fn geohash_decode_output(field: &[Field]) -> PolarsResult<Field> {
     let v: Vec<Field> = vec![
-        Field::new("longitude", Float64),
-        Field::new("latitude", Float64),
+        Field::new("longitude", DataType::Float64),
+        Field::new("latitude", DataType::Float64),
     ];
-    Ok(Field::new(field[0].name(), Struct(v)))
+    Ok(Field::new(field[0].name(), DataType::Struct(v)))
 }
 
 #[polars_expr(output_type_func=geohash_decode_output)]
@@ -171,16 +169,16 @@ fn ghash_decode(inputs: &[Series]) -> PolarsResult<Series> {
 
 pub fn geohash_neighbors_output(field: &[Field]) -> PolarsResult<Field> {
     let v: Vec<Field> = vec![
-        Field::new("n", String),
-        Field::new("ne", String),
-        Field::new("e", String),
-        Field::new("se", String),
-        Field::new("s", String),
-        Field::new("sw", String),
-        Field::new("w", String),
-        Field::new("nw", String),
+        Field::new("n", DataType::String),
+        Field::new("ne", DataType::String),
+        Field::new("e", DataType::String),
+        Field::new("se", DataType::String),
+        Field::new("s", DataType::String),
+        Field::new("sw", DataType::String),
+        Field::new("w", DataType::String),
+        Field::new("nw", DataType::String),
     ];
-    Ok(Field::new(field[0].name(), Struct(v)))
+    Ok(Field::new(field[0].name(), DataType::Struct(v)))
 }
 
 #[polars_expr(output_type_func=geohash_neighbors_output)]

--- a/polars_hash/polars_hash/src/lib.rs
+++ b/polars_hash/polars_hash/src/lib.rs
@@ -4,13 +4,6 @@ mod sha_hashers;
 use pyo3::types::PyModule;
 use pyo3::{pymodule, PyResult, Python};
 
-#[cfg(target_os = "linux")]
-use jemallocator::Jemalloc;
-
-#[global_allocator]
-#[cfg(target_os = "linux")]
-static ALLOC: Jemalloc = Jemalloc;
-
 #[pymodule]
 fn _internal(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add("__version__", env!("CARGO_PKG_VERSION"))?;


### PR DESCRIPTION
This PR updates `polars-hash` to support `polars >= 1.0.0`.
There were a few internal API changes in Polars that required adjustments.

Claude helped me with these changes. I hope they make sense.

Here is his explanation regarding Jemalloc removal:

> Modern Polars handles memory allocation differently, and the custom allocator was causing the PyCapsule_Import error

This was the original error message:

```
ERROR tests/assets - pyo3_runtime.PanicException: Failed to initialize new exception type.: PyErr { type: <class 'At...
```
