### PR TITLE
feat: Add HMAC SHA256

### DIFF
--- a/polars_hash/Cargo.toml
+++ b/polars_hash/Cargo.toml
@@ -26,6 +26,7 @@ mur3 = { version = "0.1.0" }
 hex = {version = "0.4"}
 uuid = { version = "1.19.0", features = ["v5"] }
 farmhash = { version = "1.1.5" }
+hmac = { version = "0.12" }
 
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/polars_hash/Cargo.toml
+++ b/polars_hash/Cargo.toml
@@ -26,7 +26,7 @@ mur3 = { version = "0.1.0" }
 hex = {version = "0.4"}
 uuid = { version = "1.19.0", features = ["v5"] }
 farmhash = { version = "1.1.5" }
-hmac = { version = "0.12" }
+hmac = { version = "0.12.1" }
 
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/polars_hash/polars_hash/__init__.py
+++ b/polars_hash/polars_hash/__init__.py
@@ -126,6 +126,26 @@ class CryptographicHashingNameSpace:
             is_elementwise=True,
         )
 
+    def hmac_sha256(self, key: str) -> pl.Expr:
+        """Takes Utf8 as input and returns hex-encoded HMAC-SHA256 string."""
+        return register_plugin_function(
+            plugin_path=Path(__file__).parent,
+            function_name="hmac_sha256",
+            args=self._expr,
+            is_elementwise=True,
+            kwargs={"key": key},
+        )
+
+    def hmac_sha256_binary(self, key: str) -> pl.Expr:
+        """Takes Utf8 as input and returns 32-byte HMAC-SHA256 as Binary."""
+        return register_plugin_function(
+            plugin_path=Path(__file__).parent,
+            function_name="hmac_sha256_binary",
+            args=self._expr,
+            is_elementwise=True,
+            kwargs={"key": key},
+        )
+
 
 @pl.api.register_expr_namespace("nchash")
 class NonCryptographicHashingNameSpace:

--- a/polars_hash/polars_hash/__init__.py
+++ b/polars_hash/polars_hash/__init__.py
@@ -126,21 +126,11 @@ class CryptographicHashingNameSpace:
             is_elementwise=True,
         )
 
-    def hmac_sha256(self, key: str) -> pl.Expr:
+    def hmac_sha256(self, *, key: str) -> pl.Expr:
         """Takes Utf8 as input and returns hex-encoded HMAC-SHA256 string."""
         return register_plugin_function(
             plugin_path=Path(__file__).parent,
             function_name="hmac_sha256",
-            args=self._expr,
-            is_elementwise=True,
-            kwargs={"key": key},
-        )
-
-    def hmac_sha256_binary(self, key: str) -> pl.Expr:
-        """Takes Utf8 as input and returns 32-byte HMAC-SHA256 as Binary."""
-        return register_plugin_function(
-            plugin_path=Path(__file__).parent,
-            function_name="hmac_sha256_binary",
             args=self._expr,
             is_elementwise=True,
             kwargs={"key": key},

--- a/polars_hash/src/expressions.rs
+++ b/polars_hash/src/expressions.rs
@@ -1,12 +1,10 @@
 use crate::geohashers::{geohash_decoder, geohash_encoder, geohash_neighbors};
 use crate::h3::h3_encoder;
+use crate::hmac_hashers::*;
 use crate::murmurhash_hashers::*;
 use crate::sha_hashers::*;
 use crate::xxhash_hashers::*;
-use hmac::{Hmac, Mac};
-use sha2::Sha256;
-
-type HmacSha256 = Hmac<Sha256>;
+use hmac::Mac;
 use polars::{
     chunked_array::ops::arity::{
         try_binary_elementwise, try_ternary_elementwise, unary_elementwise,
@@ -240,9 +238,7 @@ fn hmac_sha256(inputs: &[Series], kwargs: HmacKwargs) -> PolarsResult<Series> {
         .map_err(|e| PolarsError::ComputeError(format!("invalid HMAC key: {e}").into()))?;
     let out: StringChunked =
         ca.apply_into_string_amortized(|msg: &str, buf: &mut string::String| {
-            let mut mac = keyed_mac.clone();
-            mac.update(msg.as_bytes());
-            write!(buf, "{:x}", mac.finalize().into_bytes()).unwrap();
+            hmac_sha256_hash(msg, buf, &keyed_mac);
         });
     Ok(out.into_series())
 }

--- a/polars_hash/src/expressions.rs
+++ b/polars_hash/src/expressions.rs
@@ -237,8 +237,8 @@ fn hmac_sha256(inputs: &[Series], kwargs: HmacKwargs) -> PolarsResult<Series> {
     let keyed_mac = HmacSha256::new_from_slice(kwargs.key.as_bytes())
         .map_err(|e| PolarsError::ComputeError(format!("invalid HMAC key: {e}").into()))?;
     let out: StringChunked =
-        ca.apply_into_string_amortized(|msg: &str, buf: &mut string::String| {
-            hmac_sha256_hash(msg, buf, &keyed_mac);
+        ca.apply_into_string_amortized(|value: &str, output: &mut string::String| {
+            hmac_sha256_hash(value, output, &keyed_mac);
         });
     Ok(out.into_series())
 }

--- a/polars_hash/src/expressions.rs
+++ b/polars_hash/src/expressions.rs
@@ -3,6 +3,10 @@ use crate::h3::h3_encoder;
 use crate::murmurhash_hashers::*;
 use crate::sha_hashers::*;
 use crate::xxhash_hashers::*;
+use hmac::{Hmac, Mac};
+use sha2::Sha256;
+
+type HmacSha256 = Hmac<Sha256>;
 use polars::{
     chunked_array::ops::arity::{
         try_binary_elementwise, try_ternary_elementwise, unary_elementwise,
@@ -33,6 +37,11 @@ struct SeedKwargs64bit {
 #[derive(Deserialize)]
 struct LengthKwargs {
     length: usize,
+}
+
+#[derive(Deserialize)]
+struct HmacKwargs {
+    key: string::String,
 }
 
 pub fn blake3_hash_str(value: &str, output: &mut string::String) {
@@ -215,12 +224,40 @@ fn sha3_224(inputs: &[Series]) -> PolarsResult<Series> {
 
 #[polars_expr(output_type=String)]
 fn sha3_shake128(inputs: &[Series], kwargs: LengthKwargs) -> PolarsResult<Series> {
-
     let ca = inputs[0].str()?;
-    let out: StringChunked = ca.apply_into_string_amortized(|value: &str, output: &mut string::String| {
-        sha3_shake128_hash(value, output, kwargs.length)
-    });
+    let out: StringChunked =
+        ca.apply_into_string_amortized(|value: &str, output: &mut string::String| {
+            sha3_shake128_hash(value, output, kwargs.length)
+        });
 
+    Ok(out.into_series())
+}
+
+#[polars_expr(output_type=String)]
+fn hmac_sha256(inputs: &[Series], kwargs: HmacKwargs) -> PolarsResult<Series> {
+    let ca = inputs[0].str()?;
+    let template = HmacSha256::new_from_slice(kwargs.key.as_bytes())
+        .map_err(|e| PolarsError::ComputeError(format!("invalid HMAC key: {e}").into()))?;
+    let out: StringChunked = ca.apply_into_string_amortized(|msg, buf| {
+        let mut mac = template.clone();
+        mac.update(msg.as_bytes());
+        write!(buf, "{:x}", mac.finalize().into_bytes()).unwrap();
+    });
+    Ok(out.into_series())
+}
+
+#[polars_expr(output_type=Binary)]
+fn hmac_sha256_binary(inputs: &[Series], kwargs: HmacKwargs) -> PolarsResult<Series> {
+    let ca = inputs[0].str()?;
+    let template = HmacSha256::new_from_slice(kwargs.key.as_bytes())
+        .map_err(|e| PolarsError::ComputeError(format!("invalid HMAC key: {e}").into()))?;
+    let out: ChunkedArray<BinaryType> = unary_elementwise(ca, |opt_msg| {
+        opt_msg.map(|msg| {
+            let mut mac = template.clone();
+            mac.update(msg.as_bytes());
+            mac.finalize().into_bytes().to_vec()
+        })
+    });
     Ok(out.into_series())
 }
 
@@ -413,12 +450,17 @@ fn uuid5(inputs: &[Series]) -> PolarsResult<Series> {
         "url" => uuid::Uuid::NAMESPACE_URL,
         "oid" => uuid::Uuid::NAMESPACE_OID,
         "x500" => uuid::Uuid::NAMESPACE_X500,
-        _ => uuid::Uuid::parse_str(ns_value)
-            .map_err(|e| PolarsError::ComputeError(format!("Invalid namespace '{}': {}", ns_value, e).into()))?,
+        _ => uuid::Uuid::parse_str(ns_value).map_err(|e| {
+            PolarsError::ComputeError(format!("Invalid namespace '{}': {}", ns_value, e).into())
+        })?,
     };
 
     let out: StringChunked = ca.apply_into_string_amortized(|value, output| {
-        output.push_str(&uuid::Uuid::new_v5(&namespace, value.as_bytes()).hyphenated().to_string())
+        output.push_str(
+            &uuid::Uuid::new_v5(&namespace, value.as_bytes())
+                .hyphenated()
+                .to_string(),
+        )
     });
     Ok(out.into_series())
 }
@@ -427,13 +469,14 @@ fn uuid5(inputs: &[Series]) -> PolarsResult<Series> {
 fn uuid5_concat(inputs: &[Series]) -> PolarsResult<Series> {
     let col1 = inputs[0].str()?;
     let col2 = inputs[1].str()?;
-    
+
     let out: StringChunked = col1
         .into_iter()
         .zip(col2.into_iter())
         .map(|(a_opt, b_opt)| {
             a_opt.map(|a| {
-                let mut input = string::String::with_capacity(a.len() + b_opt.map_or(0, |b| b.len()));
+                let mut input =
+                    string::String::with_capacity(a.len() + b_opt.map_or(0, |b| b.len()));
                 input.push_str(a);
                 if let Some(b) = b_opt {
                     input.push_str(b);
@@ -444,7 +487,7 @@ fn uuid5_concat(inputs: &[Series]) -> PolarsResult<Series> {
             })
         })
         .collect();
-    
+
     Ok(out.into_series())
 }
 
@@ -455,7 +498,7 @@ fn uuid5_concat_default(inputs: &[Series]) -> PolarsResult<Series> {
     let col2 = col2_casted.str()?;
     let default = inputs[2].str()?;
     let default_val = default.get(0).unwrap_or("a");
-    
+
     let out: StringChunked = col1
         .into_iter()
         .zip(col2.into_iter())
@@ -471,6 +514,6 @@ fn uuid5_concat_default(inputs: &[Series]) -> PolarsResult<Series> {
             })
         })
         .collect();
-    
+
     Ok(out.into_series())
 }

--- a/polars_hash/src/expressions.rs
+++ b/polars_hash/src/expressions.rs
@@ -238,26 +238,12 @@ fn hmac_sha256(inputs: &[Series], kwargs: HmacKwargs) -> PolarsResult<Series> {
     let ca = inputs[0].str()?;
     let keyed_mac = HmacSha256::new_from_slice(kwargs.key.as_bytes())
         .map_err(|e| PolarsError::ComputeError(format!("invalid HMAC key: {e}").into()))?;
-    let out: StringChunked = ca.apply_into_string_amortized(|msg, buf| {
-        let mut mac = keyed_mac.clone();
-        mac.update(msg.as_bytes());
-        write!(buf, "{:x}", mac.finalize().into_bytes()).unwrap();
-    });
-    Ok(out.into_series())
-}
-
-#[polars_expr(output_type=Binary)]
-fn hmac_sha256_binary(inputs: &[Series], kwargs: HmacKwargs) -> PolarsResult<Series> {
-    let ca = inputs[0].str()?;
-    let keyed_mac = HmacSha256::new_from_slice(kwargs.key.as_bytes())
-        .map_err(|e| PolarsError::ComputeError(format!("invalid HMAC key: {e}").into()))?;
-    let out: ChunkedArray<BinaryType> = unary_elementwise(ca, |opt_msg| {
-        opt_msg.map(|msg| {
+    let out: StringChunked =
+        ca.apply_into_string_amortized(|msg: &str, buf: &mut string::String| {
             let mut mac = keyed_mac.clone();
             mac.update(msg.as_bytes());
-            mac.finalize().into_bytes().to_vec()
-        })
-    });
+            write!(buf, "{:x}", mac.finalize().into_bytes()).unwrap();
+        });
     Ok(out.into_series())
 }
 

--- a/polars_hash/src/expressions.rs
+++ b/polars_hash/src/expressions.rs
@@ -236,10 +236,10 @@ fn sha3_shake128(inputs: &[Series], kwargs: LengthKwargs) -> PolarsResult<Series
 #[polars_expr(output_type=String)]
 fn hmac_sha256(inputs: &[Series], kwargs: HmacKwargs) -> PolarsResult<Series> {
     let ca = inputs[0].str()?;
-    let template = HmacSha256::new_from_slice(kwargs.key.as_bytes())
+    let keyed_mac = HmacSha256::new_from_slice(kwargs.key.as_bytes())
         .map_err(|e| PolarsError::ComputeError(format!("invalid HMAC key: {e}").into()))?;
     let out: StringChunked = ca.apply_into_string_amortized(|msg, buf| {
-        let mut mac = template.clone();
+        let mut mac = keyed_mac.clone();
         mac.update(msg.as_bytes());
         write!(buf, "{:x}", mac.finalize().into_bytes()).unwrap();
     });
@@ -249,11 +249,11 @@ fn hmac_sha256(inputs: &[Series], kwargs: HmacKwargs) -> PolarsResult<Series> {
 #[polars_expr(output_type=Binary)]
 fn hmac_sha256_binary(inputs: &[Series], kwargs: HmacKwargs) -> PolarsResult<Series> {
     let ca = inputs[0].str()?;
-    let template = HmacSha256::new_from_slice(kwargs.key.as_bytes())
+    let keyed_mac = HmacSha256::new_from_slice(kwargs.key.as_bytes())
         .map_err(|e| PolarsError::ComputeError(format!("invalid HMAC key: {e}").into()))?;
     let out: ChunkedArray<BinaryType> = unary_elementwise(ca, |opt_msg| {
         opt_msg.map(|msg| {
-            let mut mac = template.clone();
+            let mut mac = keyed_mac.clone();
             mac.update(msg.as_bytes());
             mac.finalize().into_bytes().to_vec()
         })

--- a/polars_hash/src/hmac_hashers.rs
+++ b/polars_hash/src/hmac_hashers.rs
@@ -1,0 +1,11 @@
+use hmac::{Hmac, Mac};
+use sha2::Sha256;
+use std::fmt::Write;
+
+pub type HmacSha256 = Hmac<Sha256>;
+
+pub fn hmac_sha256_hash(value: &str, output: &mut String, keyed_mac: &HmacSha256) {
+    let mut mac = keyed_mac.clone();
+    mac.update(value.as_bytes());
+    write!(output, "{:x}", mac.finalize().into_bytes()).unwrap()
+}

--- a/polars_hash/src/lib.rs
+++ b/polars_hash/src/lib.rs
@@ -1,6 +1,7 @@
 mod expressions;
 mod geohashers;
 mod h3;
+mod hmac_hashers;
 mod murmurhash_hashers;
 mod sha_hashers;
 mod xxhash_hashers;

--- a/polars_hash/src/sha_hashers.rs
+++ b/polars_hash/src/sha_hashers.rs
@@ -1,6 +1,9 @@
 use sha1::Sha1;
 use sha2::{Digest, Sha224, Sha256, Sha384, Sha512};
-use sha3::{digest::{ExtendableOutput, Update, XofReader}, Sha3_224, Sha3_256, Sha3_384, Sha3_512, Shake128};
+use sha3::{
+    digest::{ExtendableOutput, Update, XofReader},
+    Sha3_224, Sha3_256, Sha3_384, Sha3_512, Shake128,
+};
 use std::fmt::Write;
 
 pub fn sha1_hash(value: &str, output: &mut String) {

--- a/polars_hash/tests/test_hash.py
+++ b/polars_hash/tests/test_hash.py
@@ -37,25 +37,23 @@ def test_sha256():
 
 
 def test_hmac_sha256():
-    result = pl.select(pl.lit("hello_world").chash.hmac_sha256(key="secret"))  # type: ignore
+    df = pl.DataFrame({"literal": ["hello_world", None, ""]})
+    result = df.select(pl.col("literal").chash.hmac_sha256(key="secret"))  # type: ignore
 
     expected = pl.DataFrame(
         [
             pl.Series(
                 "literal",
-                ["e0f5b5bb7264e77b340a55a694a6c9ca4edc035c394c703a0408f099563be1ca"],
+                [
+                    "e0f5b5bb7264e77b340a55a694a6c9ca4edc035c394c703a0408f099563be1ca",
+                    None,
+                    "f9e66e179b6747ae54108f82f8ade8b3c25d76fd30afde6c395822c530196169",
+                ],
                 dtype=pl.Utf8,
             ),
         ]
     )
     assert_frame_equal(result, expected)
-
-
-def test_hmac_sha256_null():
-    df = pl.DataFrame({"literal": ["hello_world", None, ""]})
-    result = df.select(pl.col("literal").chash.hmac_sha256(key="secret"))  # type: ignore
-
-    assert result["literal"][1] is None
 
 
 def test_sha3_shake128():

--- a/polars_hash/tests/test_hash.py
+++ b/polars_hash/tests/test_hash.py
@@ -51,6 +51,13 @@ def test_hmac_sha256():
     assert_frame_equal(result, expected)
 
 
+def test_hmac_sha256_null():
+    df = pl.DataFrame({"literal": ["hello_world", None, ""]})
+    result = df.select(pl.col("literal").chash.hmac_sha256(key="secret"))  # type: ignore
+
+    assert result["literal"][1] is None
+
+
 def test_sha3_shake128():
     result = pl.select(pl.lit("hello_world").chash.sha3_shake128(length=10))  # type: ignore
 

--- a/polars_hash/tests/test_hash.py
+++ b/polars_hash/tests/test_hash.py
@@ -36,6 +36,40 @@ def test_sha256():
     assert_frame_equal(result, expected)
 
 
+def test_hmac_sha256():
+    result = pl.select(pl.lit("hello_world").chash.hmac_sha256(key="secret"))  # type: ignore
+
+    expected = pl.DataFrame(
+        [
+            pl.Series(
+                "literal",
+                ["e0f5b5bb7264e77b340a55a694a6c9ca4edc035c394c703a0408f099563be1ca"],
+                dtype=pl.Utf8,
+            ),
+        ]
+    )
+    assert_frame_equal(result, expected)
+
+
+def test_hmac_sha256_binary():
+    result = pl.select(pl.lit("hello_world").chash.hmac_sha256_binary(key="secret"))  # type: ignore
+
+    expected = pl.DataFrame(
+        [
+            pl.Series(
+                "literal",
+                [
+                    bytes.fromhex(
+                        "e0f5b5bb7264e77b340a55a694a6c9ca4edc035c394c703a0408f099563be1ca"
+                    )
+                ],
+                dtype=pl.Binary,
+            ),
+        ]
+    )
+    assert_frame_equal(result, expected)
+
+
 def test_sha3_shake128():
     result = pl.select(pl.lit("hello_world").chash.sha3_shake128(length=10))  # type: ignore
 

--- a/polars_hash/tests/test_hash.py
+++ b/polars_hash/tests/test_hash.py
@@ -51,25 +51,6 @@ def test_hmac_sha256():
     assert_frame_equal(result, expected)
 
 
-def test_hmac_sha256_binary():
-    result = pl.select(pl.lit("hello_world").chash.hmac_sha256_binary(key="secret"))  # type: ignore
-
-    expected = pl.DataFrame(
-        [
-            pl.Series(
-                "literal",
-                [
-                    bytes.fromhex(
-                        "e0f5b5bb7264e77b340a55a694a6c9ca4edc035c394c703a0408f099563be1ca"
-                    )
-                ],
-                dtype=pl.Binary,
-            ),
-        ]
-    )
-    assert_frame_equal(result, expected)
-
-
 def test_sha3_shake128():
     result = pl.select(pl.lit("hello_world").chash.sha3_shake128(length=10))  # type: ignore
 


### PR DESCRIPTION
## What

* Add HMAC-SHA256 to chash namespace
* Adds `col.chash.hmac_sha256(key=...)` which returns a hex-encoded HMAC-SHA256 string, consistent with the existing cryptographic hashing API.
* Add new `hmac_hashers.rs` file so stateless HMAC hashers can live together without import clashes
* When applying `make format` it did format some old bits of the code.
                                                                                                                                                                                
## Changes
* New `hmac_sha256` expression backed by the hmac + sha2 crates                                                                                                                         
* Key is pre-initialized once and cloned per row for efficiency 

Test coverage:
* Happy path with known expected value                                                                                                                                                
* Null propagation                                                                                                                                                                  