### PR TITLE
fix: allow binary return type on 128bit hashers

### DIFF
--- a/polars_hash/Cargo.lock
+++ b/polars_hash/Cargo.lock
@@ -2434,7 +2434,7 @@ dependencies = [
 
 [[package]]
 name = "polars_hash"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "blake3",
  "cityhash-rs",

--- a/polars_hash/Cargo.toml
+++ b/polars_hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polars_hash"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 
 [lib]

--- a/polars_hash/polars_hash/__init__.py
+++ b/polars_hash/polars_hash/__init__.py
@@ -4,7 +4,7 @@ import warnings
 from collections.abc import Iterable
 from enum import Enum
 from pathlib import Path
-from typing import Any, Protocol, cast
+from typing import Any, Literal, Protocol, cast
 
 import polars as pl
 from polars.plugins import register_plugin_function
@@ -121,9 +121,15 @@ class NonCryptographicHashingNameSpace:
         """Takes Utf8 or Binary as input and returns uint32 hash with murmur32."""
         return _plugin("murmur32", self._expr, seed=seed)
 
-    def murmur128(self, *, seed: int = 0) -> pl.Expr:
-        """Takes Utf8 or Binary as input and returns uint128 hash with murmur128."""
-        return _plugin("murmur128", self._expr, seed=seed)
+    def murmur128(self, *, seed: int = 0, return_binary: bool = False) -> pl.Expr:
+        """Takes Utf8 or Binary as input and returns uint128 hash with murmur128.
+
+        Set `return_binary` to get the hash as 16 Binary bytes, least significant
+        byte first. Use it where the target of a write has no 128-bit integer. The
+        bytes and the integer hold the same hash. Those bytes are also the digest
+        MurmurHash3 writes, which is what `mmh3.hash_bytes` gives.
+        """
+        return _plugin("murmur128", self._expr, seed=seed, return_binary=return_binary)
 
     def xxhash32(self, *, seed: int = 0) -> pl.Expr:
         """Takes Utf8 or Binary as input and returns uint32 hash with xxhash32."""
@@ -137,9 +143,40 @@ class NonCryptographicHashingNameSpace:
         """Takes Utf8 or Binary as input and returns uint64 hash with XXH3 64bit."""
         return _plugin("xxh3_64", self._expr, seed=_encode_u64_seed(seed))
 
-    def xxh3_128(self, *, seed: int = 0) -> pl.Expr:
-        """Takes Utf8 or Binary as input and returns uint128 hash with XXH3 128bit."""
-        return _plugin("xxh3_128", self._expr, seed=_encode_u64_seed(seed))
+    def xxh3_128(
+        self,
+        *,
+        seed: int = 0,
+        return_binary: bool = False,
+        byte_order: Literal["little", "big"] | None = None,
+    ) -> pl.Expr:
+        """Takes Utf8 or Binary as input and returns uint128 hash with XXH3 128bit.
+
+        Set `return_binary` to get the hash as 16 Binary bytes. Use it where the
+        target of a write has no 128-bit integer.
+
+        `byte_order` says how those bytes read. "big" is the digest XXH3 itself
+        writes, which is what `xxhash.xxh128_digest` gives. "little" is the bytes of
+        the integer, which is what this expression wrote before 0.8.0. The default is
+        "little" and it warns, because the compatible order is not the correct one.
+        """
+        if byte_order not in (None, "little", "big"):
+            msg = f"`byte_order` must be 'little' or 'big', got {byte_order!r}"
+            raise ValueError(msg)
+        if return_binary and byte_order is None:
+            warnings.warn(
+                "xxh3_128 binary defaults to little-endian for compatibility with older polars-hash versions. "
+                "XXH3 canonicalises big-endian. Set byte_order to silence this.",
+                UserWarning,
+                stacklevel=2,
+            )
+        return _plugin(
+            "xxh3_128",
+            self._expr,
+            seed=_encode_u64_seed(seed),
+            return_binary=return_binary,
+            big_endian=byte_order == "big",
+        )
 
     def farmhash32(self) -> pl.Expr:
         """Takes Utf8 or Binary as input and returns uint32 hash with FarmHash fingerprint32."""
@@ -164,9 +201,14 @@ class NonCryptographicHashingNameSpace:
 
         return _plugin("cityhash64_with_seed", self._expr, seed=_encode_u64_seed(seed))
 
-    def cityhash128(self) -> pl.Expr:
-        """Takes Utf8 or Binary as input and returns uint128 hash with CityHash128."""
-        return _plugin("cityhash128", self._expr)
+    def cityhash128(self, *, return_binary: bool = False) -> pl.Expr:
+        """Takes Utf8 or Binary as input and returns uint128 hash with CityHash128.
+
+        Set `return_binary` to get the hash as 16 Binary bytes, least significant
+        byte first. Use it where the target of a write has no 128-bit integer. The
+        bytes and the integer hold the same hash.
+        """
+        return _plugin("cityhash128", self._expr, return_binary=return_binary)
 
     def gxhash32(self, *, seed: int = 0) -> pl.Expr:
         """Takes Utf8 or Binary as input and returns uint32 hash with GxHash."""
@@ -176,9 +218,19 @@ class NonCryptographicHashingNameSpace:
         """Takes Utf8 or Binary as input and returns uint64 hash with GxHash."""
         return _plugin("gxhash64", self._expr, seed=_encode_u64_seed(seed))
 
-    def gxhash128(self, *, seed: int = 0) -> pl.Expr:
-        """Takes Utf8 or Binary as input and returns uint128 hash with GxHash."""
-        return _plugin("gxhash128", self._expr, seed=_encode_u64_seed(seed))
+    def gxhash128(self, *, seed: int = 0, return_binary: bool = False) -> pl.Expr:
+        """Takes Utf8 or Binary as input and returns uint128 hash with GxHash.
+
+        Set `return_binary` to get the hash as 16 Binary bytes, least significant
+        byte first. Use it where the target of a write has no 128-bit integer. The
+        bytes and the integer hold the same hash.
+        """
+        return _plugin(
+            "gxhash128",
+            self._expr,
+            seed=_encode_u64_seed(seed),
+            return_binary=return_binary,
+        )
 
 
 def _length_expr(length: int | str | pl.Expr) -> pl.Expr:

--- a/polars_hash/src/expressions.rs
+++ b/polars_hash/src/expressions.rs
@@ -3,7 +3,9 @@ use crate::h3::h3_encoder;
 use crate::hmac_hashers::*;
 use crate::murmurhash_hashers::*;
 use crate::sha_hashers::*;
-use crate::shared::{float_arg, hash_bytes, hash_bytes_into_string, integer_arg, scalar_arg};
+use crate::shared::{
+    float_arg, hash_bytes, hash_bytes_into_binary, hash_bytes_into_string, integer_arg, scalar_arg,
+};
 use crate::timehashers::{
     epoch_seconds, hash_column, timehash_decoder, timehash_encoder, timehash_neighbors,
     validate_precision,
@@ -37,6 +39,55 @@ struct SeedKwargs32bit {
 #[derive(Deserialize)]
 struct SeedKwargs64bit {
     seed: i64,
+}
+
+/// A 32-bit seed and the choice of output data type, for a hasher of 128 bits.
+#[derive(Deserialize)]
+struct Seed32AndBinaryKwargs {
+    seed: u32,
+    return_binary: bool,
+}
+
+/// A 64-bit seed and the choice of output data type, for a hasher of 128 bits. The
+/// seed travels as an `i64` for the reason [`SeedKwargs64bit`] gives.
+#[derive(Deserialize)]
+struct Seed64AndBinaryKwargs {
+    seed: i64,
+    return_binary: bool,
+}
+
+/// What [`Seed64AndBinaryKwargs`] holds, and the byte order of a binary output. XXH3
+/// is the one hasher here whose own digest is not the bytes of the integer, so it is
+/// the one hasher that takes an order. The Python side reads the name of the order
+/// and sends the answer, and therefore this holds no name to reject.
+#[derive(Deserialize)]
+struct Xxh3Kwargs {
+    seed: i64,
+    return_binary: bool,
+    big_endian: bool,
+}
+
+/// The choice of output data type alone. Every 128-bit hasher sends this kwarg, and
+/// each one sends a seed of its own width, or no seed. Serde reads the field it knows
+/// and passes over the rest, so one struct serves all of them.
+#[derive(Deserialize)]
+struct BinaryKwargs {
+    return_binary: bool,
+}
+
+/// Gives the data type that a 128-bit hasher writes.
+///
+/// The output type of a plugin expression comes from a declaration, and not from the
+/// series the expression makes. A kwarg that chooses the type must therefore reach
+/// this function as well, which `output_type_func_with_kwargs` does. The name follows
+/// the first input column, which is what a plain `output_type` declaration does.
+fn hash_128_output(fields: &[Field], kwargs: BinaryKwargs) -> PolarsResult<Field> {
+    let dtype = if kwargs.return_binary {
+        DataType::Binary
+    } else {
+        DataType::UInt128
+    };
+    Ok(Field::new(fields[0].name().clone(), dtype))
 }
 
 #[derive(Deserialize)]
@@ -138,8 +189,12 @@ fn cityhash64_with_seed(inputs: &[Series], kwargs: SeedKwargs64bit) -> PolarsRes
     Ok(out.into_series())
 }
 
-#[polars_expr(output_type=UInt128)]
-fn cityhash128(inputs: &[Series]) -> PolarsResult<Series> {
+#[polars_expr(output_type_func_with_kwargs=hash_128_output)]
+fn cityhash128(inputs: &[Series], kwargs: BinaryKwargs) -> PolarsResult<Series> {
+    if kwargs.return_binary {
+        let out = hash_bytes_into_binary(&inputs[0], |v| cityhash_128(v).to_le_bytes())?;
+        return Ok(out.into_series());
+    }
     let out: UInt128Chunked = hash_bytes(&inputs[0], cityhash_128)?;
     Ok(out.into_series())
 }
@@ -158,9 +213,13 @@ fn gxhash64(inputs: &[Series], kwargs: SeedKwargs64bit) -> PolarsResult<Series> 
     Ok(out.into_series())
 }
 
-#[polars_expr(output_type=UInt128)]
-fn gxhash128(inputs: &[Series], kwargs: SeedKwargs64bit) -> PolarsResult<Series> {
+#[polars_expr(output_type_func_with_kwargs=hash_128_output)]
+fn gxhash128(inputs: &[Series], kwargs: Seed64AndBinaryKwargs) -> PolarsResult<Series> {
     let seed = kwargs.seed;
+    if kwargs.return_binary {
+        let out = hash_bytes_into_binary(&inputs[0], |v| gxhash_128(v, seed).to_le_bytes())?;
+        return Ok(out.into_series());
+    }
     let out: UInt128Chunked = hash_bytes(&inputs[0], |v| gxhash_128(v, seed))?;
     Ok(out.into_series())
 }
@@ -398,9 +457,13 @@ fn murmur32(inputs: &[Series], kwargs: SeedKwargs32bit) -> PolarsResult<Series> 
     Ok(out.into_series())
 }
 
-#[polars_expr(output_type=UInt128)]
-fn murmur128(inputs: &[Series], kwargs: SeedKwargs32bit) -> PolarsResult<Series> {
+#[polars_expr(output_type_func_with_kwargs=hash_128_output)]
+fn murmur128(inputs: &[Series], kwargs: Seed32AndBinaryKwargs) -> PolarsResult<Series> {
     let seed = kwargs.seed;
+    if kwargs.return_binary {
+        let out = hash_bytes_into_binary(&inputs[0], |v| murmurhash3_128(v, seed).to_le_bytes())?;
+        return Ok(out.into_series());
+    }
     let out: UInt128Chunked = hash_bytes(&inputs[0], |v| murmurhash3_128(v, seed))?;
     Ok(out.into_series())
 }
@@ -426,9 +489,20 @@ fn xxh3_64(inputs: &[Series], kwargs: SeedKwargs64bit) -> PolarsResult<Series> {
     Ok(out.into_series())
 }
 
-#[polars_expr(output_type=UInt128)]
-fn xxh3_128(inputs: &[Series], kwargs: SeedKwargs64bit) -> PolarsResult<Series> {
+/// Big-endian bytes are the digest that `XXH128_canonicalFromHash` writes. Little-endian
+/// bytes are the bytes of the integer, which is what this expression wrote before the
+/// output became `UInt128`, and therefore what a reader from that time expects.
+#[polars_expr(output_type_func_with_kwargs=hash_128_output)]
+fn xxh3_128(inputs: &[Series], kwargs: Xxh3Kwargs) -> PolarsResult<Series> {
     let seed = kwargs.seed as u64;
+    if kwargs.return_binary {
+        let out = if kwargs.big_endian {
+            hash_bytes_into_binary(&inputs[0], |v| xxhash3_128(v, seed).to_be_bytes())?
+        } else {
+            hash_bytes_into_binary(&inputs[0], |v| xxhash3_128(v, seed).to_le_bytes())?
+        };
+        return Ok(out.into_series());
+    }
     let out: UInt128Chunked = hash_bytes(&inputs[0], |v| xxhash3_128(v, seed))?;
     Ok(out.into_series())
 }

--- a/polars_hash/src/shared.rs
+++ b/polars_hash/src/shared.rs
@@ -53,6 +53,41 @@ where
     }
 }
 
+/// The equivalent of [`hash_bytes`] for a digest of a set number of bytes.
+///
+/// [`hash_bytes`] cannot make a `BinaryChunked` from an array of bytes. It collects
+/// what `ArrayFromIter` accepts, and that trait reads a slice or a `Vec`. An array
+/// therefore needs a `Vec` of its own for each row. A builder takes the array as a
+/// slice instead, and writes it straight into the one buffer of the column.
+pub fn hash_bytes_into_binary<const N: usize, F>(s: &Series, op: F) -> PolarsResult<BinaryChunked>
+where
+    F: Fn(&[u8]) -> [u8; N],
+{
+    let mut builder = BinaryChunkedBuilder::new(s.name().clone(), s.len());
+    match s.dtype() {
+        DataType::String => {
+            for value in s.str()?.iter() {
+                match value {
+                    Some(value) => builder.append_value(op(value.as_bytes())),
+                    None => builder.append_null(),
+                }
+            }
+        }
+        DataType::Binary => {
+            for value in s.binary()?.iter() {
+                match value {
+                    Some(value) => builder.append_value(op(value)),
+                    None => builder.append_null(),
+                }
+            }
+        }
+        dtype => polars_bail!(
+            InvalidOperation: "expected `String` or `Binary` input, got `{}`", dtype
+        ),
+    }
+    Ok(builder.finish())
+}
+
 /// Coerce an integer argument to Int64. `_length_expr` already casts on the Python
 /// side, so this only bites callers using `register_plugin_function` directly -- but
 /// the three encoders used to disagree about which widths they accepted.

--- a/polars_hash/tests/test_hash.py
+++ b/polars_hash/tests/test_hash.py
@@ -450,19 +450,24 @@ _BYTE_HASHERS = [
     ("nchash", "wyhash", {}),
     ("nchash", "murmur32", {}),
     ("nchash", "murmur128", {}),
+    ("nchash", "murmur128", {"return_binary": True}),
     ("nchash", "xxhash32", {}),
     ("nchash", "xxhash64", {}),
     ("nchash", "xxh3_64", {}),
     ("nchash", "xxh3_128", {}),
+    ("nchash", "xxh3_128", {"return_binary": True, "byte_order": "little"}),
+    ("nchash", "xxh3_128", {"return_binary": True, "byte_order": "big"}),
     ("nchash", "farmhash32", {}),
     ("nchash", "farmhash64", {}),
     ("nchash", "cityhash32", {}),
     ("nchash", "cityhash64", {}),
     ("nchash", "cityhash64", {"seed": 7}),
     ("nchash", "cityhash128", {}),
+    ("nchash", "cityhash128", {"return_binary": True}),
     ("nchash", "gxhash32", {}),
     ("nchash", "gxhash64", {}),
     ("nchash", "gxhash128", {}),
+    ("nchash", "gxhash128", {"return_binary": True}),
     ("nchash", "gxhash64", {"seed": 7}),
     ("uuidhash", "uuid5", {}),
 ]
@@ -1096,6 +1101,153 @@ def test_the_128_bit_digests_round_trip():
     assert murmur.to_bytes(16, "little").hex() == "982cf39e1c1aa55d1b079716076c8d65"
     # xxhash.xxh128_hexdigest("hello_world")
     assert f"{xxh3:032x}" == "bed31c5eaf3dc62267fb185e21fe6f03"
+
+
+# Every hasher of 128 bits writes the same hash as an integer or as bytes. The bytes
+# are for a target of a write that has no 128-bit integer, which is the reason 0.9.0
+# added `return_binary`. Each entry carries a seed if the hasher takes one.
+_HASHERS_128 = [
+    ("murmur128", {"seed": 3}),
+    ("xxh3_128", {"seed": 3, "byte_order": "little"}),
+    ("cityhash128", {}),
+    ("gxhash128", {"seed": 3}),
+]
+_HASHERS_128_IDS = [name for name, _ in _HASHERS_128]
+_SEEDED_HASHERS_128 = [(name, kw) for name, kw in _HASHERS_128 if kw]
+_SEEDED_HASHERS_128_IDS = [name for name, _ in _SEEDED_HASHERS_128]
+
+
+@pytest.mark.parametrize(("method", "kwargs"), _HASHERS_128, ids=_HASHERS_128_IDS)
+def test_return_binary_writes_the_uint128_as_bytes(method, kwargs):
+    """One hash and two data types. The bytes are the integer, least significant first.
+
+    Both directions hold: the integer makes the bytes, and the bytes make the integer
+    again. Therefore a reader of either column can reach the other one.
+    """
+    df = pl.DataFrame({"literal": ["hello_world", "", None]})
+    hasher = getattr(plh.col("literal").nchash, method)
+
+    result = df.select(
+        integer=hasher(**kwargs),
+        binary=hasher(**kwargs, return_binary=True),
+    )
+
+    assert result.dtypes == [pl.UInt128, pl.Binary]
+    for integer, binary in result.iter_rows():
+        if integer is None:
+            assert binary is None
+            continue
+        assert len(binary) == 16
+        assert binary == integer.to_bytes(16, "little")
+        assert int.from_bytes(binary, "little") == integer
+
+
+@pytest.mark.parametrize(("method", "kwargs"), _HASHERS_128, ids=_HASHERS_128_IDS)
+def test_return_binary_settles_the_data_type_before_any_row_is_read(method, kwargs):
+    """The kwarg reaches the declaration of the output type, not only the hasher.
+
+    A plugin names its output type in a declaration, and polars reads that declaration
+    to build a schema. A kwarg that chooses the type must therefore reach it as well,
+    which `output_type_func_with_kwargs` does. Without that, `collect_schema` would
+    give the type of the other branch.
+    """
+    frame = pl.LazyFrame({"literal": ["hello_world"]})
+    hasher = getattr(plh.col("literal").nchash, method)
+
+    integer = frame.select(hasher(**kwargs)).collect_schema()
+    binary = frame.select(hasher(**kwargs, return_binary=True)).collect_schema()
+
+    assert integer["literal"] == pl.UInt128
+    assert binary["literal"] == pl.Binary
+
+
+@pytest.mark.parametrize(
+    ("method", "kwargs"), _SEEDED_HASHERS_128, ids=_SEEDED_HASHERS_128_IDS
+)
+def test_return_binary_carries_the_seed(method, kwargs):
+    """The kwargs hold a seed and a choice of type, and one must not eat the other."""
+    df = pl.DataFrame({"literal": ["hello_world"]})
+    hasher = getattr(plh.col("literal").nchash, method)
+    without_seed = {name: v for name, v in kwargs.items() if name != "seed"}
+
+    result = df.select(
+        seeded=hasher(**kwargs, return_binary=True),
+        unseeded=hasher(**without_seed, return_binary=True),
+        integer=hasher(**kwargs),
+    )
+
+    assert result["seeded"][0] != result["unseeded"][0]
+    assert result["seeded"][0] == result["integer"][0].to_bytes(16, "little")
+
+
+def test_murmur128_binary_writes_the_reference_digest():
+    """`mmh3.hash_bytes("hello_world", 0)`, which 0.7.0 wrote before the type changed.
+
+    MurmurHash3 canonicalises two little-endian halves, so the bytes of the integer
+    are the digest itself. Anyone who read Binary from 0.7.0 gets the same bytes back.
+    """
+    df = pl.DataFrame({"literal": ["hello_world"]})
+
+    result = df.select(plh.col("literal").nchash.murmur128(return_binary=True))
+
+    assert result.item() == bytes.fromhex("982cf39e1c1aa55d1b079716076c8d65")
+
+
+# xxhash.xxh128_digest("hello_world")
+_XXH3_CANONICAL = bytes.fromhex("bed31c5eaf3dc62267fb185e21fe6f03")
+
+
+def test_xxh3_128_byte_order_writes_each_order():
+    """XXH3 is the one hasher here whose own digest is not the bytes of the integer.
+
+    It canonicalises big-endian, so "big" gives the digest. "little" gives the bytes
+    of the integer, which is what this expression wrote before 0.8.0. One is the
+    reverse of the other.
+    """
+    df = pl.DataFrame({"literal": ["hello_world", None]})
+    hasher = plh.col("literal").nchash.xxh3_128
+
+    result = df.select(
+        big=hasher(return_binary=True, byte_order="big"),
+        little=hasher(return_binary=True, byte_order="little"),
+    )
+
+    assert result["big"][0] == _XXH3_CANONICAL
+    assert result["little"][0] == _XXH3_CANONICAL[::-1]
+    assert result["big"][1] is None and result["little"][1] is None
+
+
+def test_xxh3_128_byte_order_defaults_to_little_with_a_warning():
+    """The compatible order is not the correct one, so the default says so once."""
+    df = pl.DataFrame({"literal": ["hello_world"]})
+
+    with pytest.warns(UserWarning, match="little-endian"):
+        result = df.select(plh.col("literal").nchash.xxh3_128(return_binary=True))
+
+    assert result.item() == _XXH3_CANONICAL[::-1]
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"return_binary": True, "byte_order": "little"},
+        {"return_binary": True, "byte_order": "big"},
+        {"return_binary": False},
+    ],
+    ids=["little", "big", "uint128"],
+)
+def test_xxh3_128_stays_quiet_when_the_order_cannot_surprise(kwargs, recwarn):
+    """A caller who names an order has read the warning, and an integer has no order."""
+    df = pl.DataFrame({"literal": ["hello_world"]})
+
+    df.select(plh.col("literal").nchash.xxh3_128(**kwargs))
+
+    assert [w for w in recwarn if issubclass(w.category, UserWarning)] == []
+
+
+def test_xxh3_128_rejects_an_order_it_does_not_know():
+    with pytest.raises(ValueError, match="must be 'little' or 'big'"):
+        plh.col("literal").nchash.xxh3_128(return_binary=True, byte_order="middle")
 
 
 def test_timehash():


### PR DESCRIPTION
Brings the option to return binary dtype, also found a correctness issue with xxh3 so you flip the byte order, but the default stays on the incorrect little endian order.

- closes https://github.com/ion-elgreco/polars-hash/issues/70